### PR TITLE
Add org wide PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+# <Feature Title>
+
+**Ticket:** <Ticket permalink here>
+
+## Description
+
+<!-- Add your description here. -->
+
+## Checklist
+
+- [ ] Ticket has been moved to Peer Review
+- [ ] The `develop` branch has been merged into this branch and conflicts resolved
+- [ ] All existing tests are passing
+- [ ] Manual testing has been completed
+- [ ] Automated tests have been added where necessary
+- [ ] Documentation has been updated where necessary
+
+## Screenshots
+
+<!-- Add your screenshots here or delete this section. -->
+
+## Usage
+
+<!-- Add any notes here that will help your reviewer test your feature locally or delete this section. -->
+
+## Notes
+
+<!-- Add any relevant notes here or delete this section. -->
+


### PR DESCRIPTION
# Add org wide PR template

**Ticket:** n/a

## Description

This adds a PR template that will be automatically applied to other repositories in [`KomodoHQ`](https://github.com/KomodoHQ). If this is not wanted, you should be able to override it with another template in that repo.

## Checklist
- ~[ ] Ticket has been moved to Peer Review~
- ~[ ] The `develop` branch has been merged into this branch and conflicts resolved~
- ~[ ] All existing tests are passing~
- ~[ ] Manual testing has been completed~
- ~[ ] Automated tests have been added where necessary~
- [ ] Documentation has been updated where necessary

## Usage

To use this, just create a PR in an Komodo repo.

## Notes

- https://github.com/github/.github
- https://github.com/getsentry/.github
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
- https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file